### PR TITLE
Fix push on pathless entries.

### DIFF
--- a/josh-sqlite/src/index.js
+++ b/josh-sqlite/src/index.js
@@ -545,7 +545,7 @@ module.exports = class JoshProvider {
     }
     if (!type) return;
     if (!isArray(type)) type = [type];
-    if (!isNil(path)) {
+    if (!isNil(path) && path !== '') {
       this.check(key, 'Object');
       const data = this.get(key);
       if (isNil(_get(data, path))) {


### PR DESCRIPTION
This fixes the 
```
CustomError [JoshPathError]: The property "" in key "a" does not exist. Please set() it or ensure() it."
```
When pusing to a top-level array.