### PR TITLE
[Errored / I'll see later] Removed an useless line, which causes bugs

### DIFF
--- a/josh-sqlite/src/utils.js
+++ b/josh-sqlite/src/utils.js
@@ -32,7 +32,6 @@ const getPaths = (data, acc = {}, basePath = null) => {
     Object.entries(data);
   const returnPaths = source.reduce((paths, [key, value]) => {
     const path = getDelimitedPath(basePath, key, !isArray(value));
-    if (isObject(value)) getPaths(value, paths, path);
     paths[path.toString()] = JSON.stringify(value);
     return paths;
   }, acc || {});


### PR DESCRIPTION
Removed an useless line in `src/utils.js`, which returned something not used. This line caused `Maximum call stack size exceeded error` because the line was calling the function itself